### PR TITLE
fixed pre commit hook

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -10,7 +10,6 @@ jobs:
   pre-commit:
     runs-on: ubuntu-latest
     steps:
-    - run: if [ ! -f "/etc/lsb-release" ] ; then echo "DISTRIB_RELEASE=18.04" > /etc/lsb-release; fi
     - uses: actions/checkout@v2
     - uses: actions/setup-python@v2
     - uses: pre-commit/action@v2.0.0

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -10,6 +10,7 @@ jobs:
   pre-commit:
     runs-on: ubuntu-latest
     steps:
+    - run: if [ ! -f "/etc/lsb-release" ] ; then echo "DISTRIB_RELEASE=18.04" > /etc/lsb-release; fi
     - uses: actions/checkout@v2
     - uses: actions/setup-python@v2
     - uses: pre-commit/action@v2.0.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,5 @@
 repos:
 -   repo: https://github.com/twof/Downstream
-    rev: 0.0.2
+    rev: 0.0.3
     hooks:
     -   id: downstream

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,6 +1,6 @@
 -   id: downstream
     name: Downstream
     description: Alerts the user to downstream dependencies of the files updated
-    entry: downstream
+    entry: Downstream
     language: swift
     verbose: true

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,6 +1,6 @@
 -   id: downstream
     name: Downstream
     description: Alerts the user to downstream dependencies of the files updated
-    entry: Downstream
+    entry: downstream
     language: swift
     verbose: true

--- a/Package.swift
+++ b/Package.swift
@@ -4,7 +4,7 @@
 import PackageDescription
 
 let package = Package(
-    name: "Downstream",
+    name: "downstream",
     dependencies: [
       .package(url: "https://github.com/jpsim/Yams.git", from: "4.0.0"),
       .package(url: "https://github.com/JohnSundell/Files", from: "4.0.0")
@@ -13,10 +13,10 @@ let package = Package(
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.
         // Targets can depend on other targets in this package, and on products in packages this package depends on.
         .target(
-            name: "Downstream",
+            name: "downstream",
             dependencies: ["Yams", "Files"]),
         .testTarget(
             name: "DownstreamTests",
-            dependencies: ["Downstream"]),
+            dependencies: ["downstream"]),
     ]
 )


### PR DESCRIPTION
Entry did not match capitalization of created executable. It was running fine locally for some reason, but on linux it was failing.